### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
-# puppet-jenkins-shared-libraries Changelog
+# Changelog
 
-## 1.0.0
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [v2.0.0] - 6-1-2018
+
+### Added
+
+- Docker build support based on presence of a docker-compose.yml file
+- Docker build information
+
+### Updated
+
+- CHANGELOG format
+- Linted README markdown
+
+## [v1.0.0]
 
 - EVERYTHING :tada:

--- a/Jenkinsfile.clean_example
+++ b/Jenkinsfile.clean_example
@@ -1,0 +1,13 @@
+node {
+  try {
+    stage('Volume Clean') {
+      sh 'docker volume prune -f'
+    }
+    currentBuild.result = 'SUCCESS'
+  } catch(Exception e) {
+    currentBuild.result = 'FAILURE'
+    slackSend channel: '#devops', failOnError: true, color: 'danger', message: 'Jenkins Docker cleanup run *FAILED*!'
+    throw e
+  }
+  slackSend channel: '#devops', failOnError: true, color: 'good', message: 'Jenkins Docker cleanup run *SUCCESSFUL*!'
+}

--- a/Jenkinsfile.example
+++ b/Jenkinsfile.example
@@ -18,4 +18,7 @@ puppet {
   R10K_DEPLOY_BRANCH = ['production', 'support']
   SLACK_CHANNEL = '#puppet'
   DEBUG = 'false'
+  DOCKER_REGISTRY_CREDS_ID = 'creds_id_to_registry'
+  DOCKER_REGISTRY_URL = 'https://hub.docker.io'
+  AWS_DEFAULT_REGION = 'us-east-1'
 }

--- a/README.md
+++ b/README.md
@@ -7,26 +7,31 @@ Testing your Puppet on every change should be a smooth process. With Jenkins pip
 If you're new to Jenkins pipelines you should go read the [documentation](https://jenkins.io/doc/book/pipeline/) before proceeding to get a sense for what to expect using this code. The rest of the setup process will assume you have basic knowledge of Jenkins or CI/CD jobs in general.
 
 OS
-  - rvm installed in the jenkins user
-  - git
-  - build-essential
-  - docker if needed for acceptance tests
+
+- rvm installed in the jenkins user
+- git
+- build-essential
+- docker if needed for acceptance tests
 
 Jenkins
-  - Version: > 2.7.3 - tested on (2.19.4 LTS)
-  
+
+- Version: > 2.7.3 - tested on (2.89.4 LTS)
+
 Plugins
-  - slack
-  - pipeline (workflow-aggregator)
-  - git
-  - timestamper
-  - credentials
-  - junit
+
+- slack
+- pipeline (workflow-aggregator)
+- git
+- timestamper
+- credentials
+- junit
 
 Scripts Approval
-- When the job runs the first time you will need to work through allowing certain functions to execute in the groovy sandbox. This is normal as not all high use groovy functions are in the default safelist but more are added all the time.
+
+When the job runs the first time you will need to work through allowing certain functions to execute in the groovy sandbox. This is normal as not all high use groovy functions are in the default safelist but more are added all the time.
 
 ### Manage with Puppet
+
 The following modules work great to manage a Jenkins instance.
 
 - maestrodev/rvm
@@ -57,25 +62,31 @@ puppet {
   R10K_DEPLOY_BRANCH = ['production', 'support']
   SLACK_CHANNEL = '#puppet'
   DEBUG = 'false'
+  DOCKER_REGISTRY_CREDS_ID = 'creds_id_to_registry'
+  DOCKER_REGISTRY_URL = 'https://hub.docker.io'
+  AWS_DEFAULT_REGION = 'us-east-1'
 }
 ```
 
 ### Required Parameters
 
-- RUBY_VERSION: Ruby version to use. [String]
-- RUBY_GEMSET: Name of the gemset to create. [String]
+- **RUBY_VERSION:** Ruby version to use. [String]
+- **RUBY_GEMSET:** Name of the gemset to create. [String]
 
 ### Optional Parameters
 
-- RUN_ACCEPTANCE: Run acceptance tests? [String] (true|false) Default: false
-- DEPLOY_WITH_R10K: Deploy branch with r10k. [String] (true|false) Default: false **NOTE:** This requires r10k to be configured web hook support. (https://forge.puppet.com/puppet/r10k#webhook-support)
-- TEST_RESULTS_DIR: Directory to look for junit output of test results. [String] Default: testresults
-- ACCEPTANCE_TESTS: Required if RUN_ACCEPTANCE is true. Map of values to use for running in the parallel step. [Map] See [below](#Acceptance Test Configuration) for more details
-- R10K_DEPLOY_URL: Required if DEPLOY_WITH_R10K is true. The URL of the Puppet server. [String]
-- R10K_DEPLOY_BASIC_AUTH_CRED_ID: If your Puppet server is behind basic auth then set a credential in Jenkins. This is the credentialsId set in the Jenkins credentials plugin. [String]
-- R10K_DEPLOY_BRANCH: Env branch(s) to deploy with r10k [List]
-- SLACK_CHANNEL: Specify the Slack channel to use for notifications. [String] Default: #puppet
-- DEBUG: Turn off Slack notifications and turn on more console output. [String] Default: false
+- **RUN_ACCEPTANCE:** Run acceptance tests? [String] (true|false) Default: false
+- **DEPLOY_WITH_R10K:** Deploy branch with r10k. [String] (true|false) Default: false **NOTE:** This requires r10k to be configured [web hook support](https://forge.puppet.com/puppet/r10k#webhook-support)
+- **TEST_RESULTS_DIR:** Directory to look for junit output of test results. [String] Default: testresults
+- **ACCEPTANCE_TESTS:** Required if RUN_ACCEPTANCE is true. Map of values to use for running in the parallel step. [Map] See [below](#Acceptance Test Configuration) for more details
+- **R10K_DEPLOY_URL:** Required if DEPLOY_WITH_R10K is true. The URL of the Puppet server. [String]
+- **R10K_DEPLOY_BASIC_AUTH_CRED_ID:** If your Puppet server is behind basic auth then set a credential in Jenkins. This is the credentialsId set in the Jenkins credentials plugin. [String]
+- **R10K_DEPLOY_BRANCH:** Env branch(s) to deploy with r10k [List]
+- **SLACK_CHANNEL:** Specify the Slack channel to use for notifications. [String] Default: #puppet
+- **DEBUG:** Turn off Slack notifications and turn on more console output. [String] Default: false
+- **DOCKER_REGISTRY_URL:** The private Docker registry URL. Required to build with Docker. [String]
+- **DOCKER_REGISTRY_CREDS_ID:** The private Docker registry credentials ID in Jenkins. Required to build with Docker. [String]
+- **AWS_DEFAULT_REGION:** The AWS region of you Elastic Container Registry
 
 ## Acceptance Test Configuration
 
@@ -92,12 +103,19 @@ ACCEPTANCE_TESTS = [
   failFast: false
 ]
 ```
+
 I went ahead and left the first item in the map the same as above but changed the second to include explanations of the values. The main part to point out here is the `puppetRvm()` wrapper function. This function is used in the shared library to run all the commands within the scope of the specified ruby version and gemset name as specified by the `RUBY_VERSION` and `RUBY_GEMSET` parameters. The wrapper function is also safe to use for anything not needing ruby as well. It is however highly advised you use the puppetRvm wrapper function to run the actual acceptance tests since that does require the ruby version and gemset that was installed earlier in the build process.
 
 ## Test Results
+
 All test results are assumed to be in JUnit format and placed in a single directory.
+
+## Docker Builds
+
+If a docker-compose.yml is present in the repo and `DOCKER_REGISTRY_URL` and `DOCKER_REGISTRY_CREDS_ID` are set builds will run with Docker. All containers are cleaned up after the build completes. Gems are stored in a Docker volume per branch (eg. puppet_master-gems). This allows for faster builds since gems are cached between runs. This can, however, lead to filling up the disk quickly it is recommended that you run a periodic clean job to remove old volumes. See Jenkinsfile.clean_example.
+
+**Note:** The current setup only works with AWS ECR but can easily be adapted to work with other private registries.
 
 ## [Changelog](CHANGELOG.md)
 
 ## [MIT License](LICENSE)
-

--- a/vars/puppetDeployDocker.groovy
+++ b/vars/puppetDeployDocker.groovy
@@ -1,0 +1,39 @@
+#!/usr/bin/env groovy
+
+def call(Map config) {
+  try {
+    stage('Deploy') {
+      milestone label: 'Deploy'
+
+      if (config.DEPLOY_WITH_R10K == 'true') {
+        try {
+          stage('Deploy'){
+            milestone label: 'Deploy'
+            def deploy_branch = config.R10K_DEPLOY_BRANCH.any {it == env.BRANCH_NAME}
+              
+              if (deploy_branch) {
+                sh returnStdout: true, script: "curl --request POST -k --url ${config.R10K_DEPLOY_URL}/payload  --header \'content-type: application/json\' ${config.BASIC_AUTH_HEADER} --data \'{\"push\":{\"changes\":[{\"new\":{\"name\":\"${env.BRANCH_NAME}\"}}]}}\'"
+
+                currentBuild.result = 'SUCCESS'
+              }
+          }
+        } catch(Exception e) {
+          junit allowEmptyResults: true, keepLongStdio: true, testResults: "${config.TEST_RESULTS_DIR}/*.xml"
+          currentBuild.result = 'FAILURE'
+          if (config.DEBUG == 'false') {
+            puppetSlack(config.SLACK_CHANNEL)
+          }
+          throw e
+        }
+      }
+
+      currentBuild.result = 'SUCCESS'
+    }
+  } catch(Exception e) {
+    currentBuild.result = 'FAILURE'
+    if (config.DEBUG == 'false') {
+      puppetSlack(config.SLACK_CHANNEL)
+    }
+    throw e
+  }
+}

--- a/vars/puppetDocker.groovy
+++ b/vars/puppetDocker.groovy
@@ -1,0 +1,35 @@
+#!/usr/bin/env groovy
+
+def call(Map config) {
+  if (!config.DOCKER_REGISTRY_CREDS_ID) {
+    error 'DOCKER_REGISTRY_CREDS_ID is required to use Docker builds'
+  }
+  if (!config.DOCKER_REGISTRY_URL){
+    error 'DOCKER_REGISTRY_URL is required to use Docker builds'
+  }
+  if (!config.AWS_DEFAULT_REGION){
+    env.AWS_DEFAULT_REGION = 'us-west-2'
+  } else {
+    env.AWS_DEFAULT_REGION = config.AWS_DEFAULT_REGION
+  }
+
+  env.BRANCH_NAME = env.BRANCH_NAME.split('-')[0].toLowerCase()
+  echo "BRANCH_NAME: ${env.BRANCH_NAME}"
+  
+  config.DOCKER_REGISTRY = config.DOCKER_REGISTRY_URL.split('https://')[1]
+  env.REPO_NAME = env.JOB_NAME.split('/')[0]
+  env.GEM_VOLUME = "${env.REPO_NAME}_${env.BRANCH_NAME}_gems"
+  
+  docker.withRegistry(config.DOCKER_REGISTRY_URL, "ecr:${env.AWS_DEFAULT_REGION}:${config.DOCKER_REGISTRY_CREDS_ID}") {
+
+    config.container = "docker run -t --rm --name ${env.BUILD_TAG} -w /app -v ${env.WORKSPACE}:/app -v ${env.GEM_VOLUME}:/gems -e RAILS_ENV=${env.RAILS_ENV} ${config.DOCKER_REGISTRY}:${env.RUBY_VERSION}"
+
+    puppetInstallDepsDocker(config)
+
+    puppetTestsDocker(config)
+
+    puppetDeployDocker(config)
+
+    sh "${config.container} chown -R 1003:1004 /app"
+  } // withRegistry
+} // top level function

--- a/vars/puppetInstallDepsDocker.groovy
+++ b/vars/puppetInstallDepsDocker.groovy
@@ -1,0 +1,19 @@
+#!/usr/bin/env groovy
+
+def call(Map config) {
+  try {
+    stage('Install Dependancies') {
+      milestone label: 'Install Dependancies'
+      retry(2) {
+        sh "${config.container} bundle install --quiet --clean --jobs=4"
+      }
+      currentBuild.result = 'SUCCESS'
+    }
+  } catch(Exception e) {
+    currentBuild.result = 'FAILURE'
+    if (config.DEBUG == 'false') {
+      puppetSlack(config.SLACK_CHANNEL)
+    }
+    throw e
+  }
+}

--- a/vars/puppetTestsDocker.groovy
+++ b/vars/puppetTestsDocker.groovy
@@ -1,0 +1,43 @@
+#!/usr/bin/env groovy
+
+def call(Map config) {
+  try {
+    stage('Unit Test') {
+      milestone label: 'Test'
+
+      sh "${config.container} rake test"
+      
+       junit allowEmptyResults: true, keepLongStdio: true, testResults: "${config.TEST_RESULTS_DIR}/*.xml"
+      currentBuild.result = 'SUCCESS'
+    }
+  } catch(Exception e) {
+     junit allowEmptyResults: true, keepLongStdio: true, testResults: "${config.TEST_RESULTS_DIR}/*.xml"
+    
+    currentBuild.result = 'FAILURE'
+    if (config.DEBUG == 'false') {
+      puppetSlack(config.SLACK_CHANNEL)
+    }
+    throw e
+  }
+
+  if(config.RUN_ACCEPTANCE == 'true') {
+    try {
+      stage('Acceptance Test'){
+        milestone label: 'Acceptance Test'
+        
+        parallel config.ACCEPTANCE_TESTS
+        
+        junit allowEmptyResults: true, keepLongStdio: true, testResults: "${config.TEST_RESULTS_DIR}/*.xml"
+        currentBuild.result = 'SUCCESS'
+      }
+    } catch(Exception e) {
+      junit allowEmptyResults: true, keepLongStdio: true, testResults: "${config.TEST_RESULTS_DIR}/*.xml"
+      
+      currentBuild.result = 'FAILURE'
+      if (config.DEBUG == 'false') {
+        puppetSlack(config.SLACK_CHANNEL)
+      }
+      throw e
+    }
+  }
+}


### PR DESCRIPTION
Added Docker build support

Removed SSH auth as it is not needed

Updated the Puppet container tag to use the full ruby version

Removed PUPPET_VERSION requirement

Updated Puppet gem volume name to use the project name as the first placeholder

Fixed file name typo

Removed Puppet test directory removal

Fixed slack call

Fixed double posts to Slack on completion

Release v2.0.0

Release of v2.0.0 of the library